### PR TITLE
Add SKColor for OSX

### DIFF
--- a/template/spritekit-osx/files/app/my_scene.rb
+++ b/template/spritekit-osx/files/app/my_scene.rb
@@ -2,7 +2,7 @@ class MyScene < SKScene
   def initWithSize(size)
     super
 
-    self.backgroundColor = NSColor.grayColor
+    self.backgroundColor = SKColor.grayColor
     my_label = SKLabelNode.labelNodeWithFontNamed("Chalkduster")
     my_label.text = "Hello, World!"
     my_label.fontSize = 30

--- a/template/spritekit-osx/files/app/sprite_kit_base.rb
+++ b/template/spritekit-osx/files/app/sprite_kit_base.rb
@@ -1,0 +1,1 @@
+SKColor = NSColor


### PR DESCRIPTION
Add an alias.
See [documentation](https://developer.apple.com/library/ios/documentation/SpriteKit/Reference/SpriteKitFunctionReference/Reference/reference.html).
